### PR TITLE
Support different newlines

### DIFF
--- a/test/lib/ex_csv/parser_test.exs
+++ b/test/lib/ex_csv/parser_test.exs
@@ -54,6 +54,14 @@ defmodule ExCsv.ParserTest do
     assert ExCsv.Parser.parse(~s<a,b,c\n,e,f>) |> body == [["a", "b", "c"], ["", "e", "f"]]
   end
 
+  test "two simple lines with return character" do
+    assert ExCsv.Parser.parse(~s<a,b,c\rd,e,f>) |> body == [["a", "b", "c"], ["d", "e", "f"]]
+  end
+
+  test "two simple lines with return and newline" do
+    assert ExCsv.Parser.parse(~s<a,b,c\r\nd,e,f>) |> body == [["a", "b", "c"], ["d", "e", "f"]]
+  end
+
   defp body({:ok, %{body: body}}), do: body
 
 end


### PR DESCRIPTION
Howdy @cargosensedev, thanks for ex_csv!

Following some discussion in Slack today and after seeing #6, I thought I'd take a stab at supporting different newlines (`\r`, `\n`, and `\r\n`).  Is this a feature you'd be willing to support?  If so, I'd be glad to incorporate the necessary feedback into this PR.

Questions/comments/concerns welcome :grinning: 
